### PR TITLE
System tworzenia ticketów i zarządzania nimi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,13 @@
+# User-specific stuff
+.idea/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
 *$py.class
 private.py
 linkdb.py
+module_roles.json
 
 # C extensions
 *.so

--- a/cogs/level.py
+++ b/cogs/level.py
@@ -3,6 +3,7 @@ from discord.ext import tasks, commands
 from pymongo import MongoClient
 import random
 from linkdb import *
+from private import guild_id
 
 mongo_client = MongoClient(link_db)
 db = mongo_client["tgm_db"]
@@ -32,7 +33,7 @@ class Level(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        guild_id = 1309556200844689459
+        #guild_id = 1309556200844689459
         user_id = str(message.author.id)
         
         if message.author.bot or not message.guild or message.guild.id != guild_id:

--- a/cogs/level.py
+++ b/cogs/level.py
@@ -9,9 +9,11 @@ mongo_client = MongoClient(link_db)
 db = mongo_client["tgm_db"]
 collection = db["tgm_levels"]
 
+
 # Funkcja licząca wymagane XP na dany poziom
 def xp_needed_for_level(level, base_xp=1000, increase=500):
     return base_xp + increase * (level - 1)
+
 
 class Level(commands.Cog):
     def __init__(self, bot):
@@ -33,9 +35,9 @@ class Level(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        #guild_id = 1309556200844689459
+        # guild_id = 1309556200844689459
         user_id = str(message.author.id)
-        
+
         if message.author.bot or not message.guild or message.guild.id != guild_id:
             return
 
@@ -46,7 +48,7 @@ class Level(commands.Cog):
                 "user_id": user_id,
                 "username": message.author.name,
                 "level": 1,
-                "xp": 0
+                "xp": 0,
             }
             self.collection.insert_one(user_data)
 
@@ -88,16 +90,18 @@ class Level(commands.Cog):
         # Zapisz do bazy
         self.collection.update_one(
             {"user_id": user_id},
-            {"$set": {"xp": new_xp, "level": level, "username": message.author.name}}
+            {"$set": {"xp": new_xp, "level": level, "username": message.author.name}},
         )
 
         # Komunikaty
         if level_up:
-            await message.channel.send(f"{message.author.mention} Gratulacje! Wbiłeś poziom {level}!")
+            await message.channel.send(
+                f"{message.author.mention} Gratulacje! Wbiłeś poziom {level}!"
+            )
             if level in role_ids and (role := message.guild.get_role(role_ids[level])):
                 await message.channel.send(
                     f"{message.author.mention} Otrzymałeś rangę {role.mention}!",
-                    allowed_mentions=discord.AllowedMentions(roles=False, users=True)
+                    allowed_mentions=discord.AllowedMentions(roles=False, users=True),
                 )
 
         # Dodaj do cooldowna
@@ -108,8 +112,10 @@ class Level(commands.Cog):
         user = user or ctx.author
         user_id = str(user.id)
         user_data = self.collection.find_one({"user_id": user_id})
-        
-        xp_emoji = discord.PartialEmoji(animated=True, name="xp_orb", id=1404378885503848489)
+
+        xp_emoji = discord.PartialEmoji(
+            animated=True, name="xp_orb", id=1404378885503848489
+        )
 
         if user_data is not None:
             level = user_data["level"]
@@ -117,14 +123,25 @@ class Level(commands.Cog):
             xp_needed = xp_needed_for_level(level)
             progress = xp / xp_needed
 
-            progress_bar = "[" + "█" * int(20 * progress) + " " * (20 - int(20 * progress)) + f"] {int(progress * 100)}%"
+            progress_bar = (
+                "["
+                + "█" * int(20 * progress)
+                + " " * (20 - int(20 * progress))
+                + f"] {int(progress * 100)}%"
+            )
 
             embed = discord.Embed(
                 title=f"Karta postępu użytkownika @{user.display_name}", color=0xA751ED
             )
             embed.add_field(name=f":bar_chart: Poziom:", value=level, inline=True)
-            embed.add_field(name=f"{xp_emoji} XP:", value=f"{xp}/{xp_needed}", inline=True)
-            embed.add_field(name=f":chart_with_upwards_trend: Postęp:", value=progress_bar, inline=False)
+            embed.add_field(
+                name=f"{xp_emoji} XP:", value=f"{xp}/{xp_needed}", inline=True
+            )
+            embed.add_field(
+                name=f":chart_with_upwards_trend: Postęp:",
+                value=progress_bar,
+                inline=False,
+            )
             embed.set_thumbnail(url=user.display_avatar.url)
 
             await ctx.respond(embed=embed)
@@ -145,10 +162,11 @@ class Level(commands.Cog):
             embed.add_field(
                 name=f"#{position} — {name}",
                 value=f"**Poziom:** {level} | **XP:** {xp}",
-                inline=False
+                inline=False,
             )
 
         await ctx.respond(embed=embed)
+
 
 def setup(bot):
     bot.add_cog(Level(bot))

--- a/cogs/level.py
+++ b/cogs/level.py
@@ -3,7 +3,6 @@ from discord.ext import tasks, commands
 from pymongo import MongoClient
 import random
 from linkdb import *
-from private import guild_id
 
 mongo_client = MongoClient(link_db)
 db = mongo_client["tgm_db"]
@@ -35,7 +34,8 @@ class Level(commands.Cog):
 
     @commands.Cog.listener()
     async def on_message(self, message):
-        # guild_id = 1309556200844689459
+        #TODO: chyba lepiej przenieść zmienne globalne do pliku private, nie?
+        guild_id = 1309556200844689459
         user_id = str(message.author.id)
 
         if message.author.bot or not message.guild or message.guild.id != guild_id:

--- a/cogs/leveladmin.py
+++ b/cogs/leveladmin.py
@@ -7,6 +7,7 @@ mongo_client = MongoClient(link_db)
 db = mongo_client["tgm_db"]
 collection = db["tgm_levels"]
 
+
 class LevelAdmin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -19,12 +20,7 @@ class LevelAdmin(commands.Cog):
         user_id = str(user.id)
         data = self._get_user_data(user_id)
         if not data:
-            data = {
-                "user_id": user_id,
-                "username": user.name,
-                "level": 1,
-                "xp": 0
-            }
+            data = {"user_id": user_id, "username": user.name, "level": 1, "xp": 0}
             self.collection.insert_one(data)
         return data
 
@@ -34,18 +30,19 @@ class LevelAdmin(commands.Cog):
         data = self._ensure_user_data(user)
         new_xp = data["xp"] + xp
         self.collection.update_one(
-            {"user_id": str(user.id)},
-            {"$set": {"xp": new_xp, "username": user.name}}
+            {"user_id": str(user.id)}, {"$set": {"xp": new_xp, "username": user.name}}
         )
-        await ctx.respond(f"✅ Dodano {xp} XP dla {user.mention}. Teraz ma {new_xp} XP.", ephemeral=True)
+        await ctx.respond(
+            f"✅ Dodano {xp} XP dla {user.mention}. Teraz ma {new_xp} XP.",
+            ephemeral=True,
+        )
 
     @discord.slash_command(description="Ustaw konkretną ilość XP.")
     @discord.default_permissions(administrator=True)
     async def set_xp(self, ctx, user: discord.User, xp: int):
         self._ensure_user_data(user)
         self.collection.update_one(
-            {"user_id": str(user.id)},
-            {"$set": {"xp": xp, "username": user.name}}
+            {"user_id": str(user.id)}, {"$set": {"xp": xp, "username": user.name}}
         )
         await ctx.respond(f"✅ Ustawiono {xp} XP dla {user.mention}.", ephemeral=True)
 
@@ -54,10 +51,12 @@ class LevelAdmin(commands.Cog):
     async def set_level(self, ctx, user: discord.User, level: int):
         self._ensure_user_data(user)
         self.collection.update_one(
-            {"user_id": str(user.id)},
-            {"$set": {"level": level, "username": user.name}}
+            {"user_id": str(user.id)}, {"$set": {"level": level, "username": user.name}}
         )
-        await ctx.respond(f"✅ Ustawiono poziom {level} dla {user.mention}.", ephemeral=True)
+        await ctx.respond(
+            f"✅ Ustawiono poziom {level} dla {user.mention}.", ephemeral=True
+        )
+
 
 def setup(bot):
     bot.add_cog(LevelAdmin(bot))

--- a/cogs/roleadmin.py
+++ b/cogs/roleadmin.py
@@ -5,25 +5,42 @@ from permissioncontroller import PermissionController
 from enum import Enum
 from permissioncontroller import ModuleName
 
+
 class TicketAction(Enum):
     ADD = "Add"
     REMOVE = "Remove"
+
 
 class RoleAdmin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
         self.moderator_roles = PermissionController()
 
-    @discord.slash_command(description="Przypisuje lub usuwa danej roli dostęp do danego modułu")
+    @discord.slash_command(
+        description="Przypisuje lub usuwa danej roli dostęp do danego modułu"
+    )
     @discord.default_permissions(administrator=True)
     @guild_only()
-    async def modrole(self, ctx, action: discord.Option(TicketAction), role: discord.Role, module: discord.Option(ModuleName)):
+    async def modrole(
+        self,
+        ctx,
+        action: discord.Option(TicketAction),
+        role: discord.Role,
+        module: discord.Option(ModuleName),
+    ):
         if action == TicketAction.ADD:
             self.moderator_roles.add_role_permission(str(role.id), module)
-            await ctx.respond(f"Rola {role.name} otrzymała dostęp do modułu {module.value}", ephemeral=True)
+            await ctx.respond(
+                f"Rola {role.name} otrzymała dostęp do modułu {module.value}",
+                ephemeral=True,
+            )
         else:
             self.moderator_roles.remove_role_permission(str(role.id), module)
-            await ctx.respond(f"Rola {role.name} utraciła dostęp do modułu {module.value}", ephemeral=True)
+            await ctx.respond(
+                f"Rola {role.name} utraciła dostęp do modułu {module.value}",
+                ephemeral=True,
+            )
+
 
 def setup(bot):
     bot.add_cog(RoleAdmin(bot))

--- a/cogs/roleadmin.py
+++ b/cogs/roleadmin.py
@@ -1,0 +1,29 @@
+import discord
+from discord import guild_only
+from discord.ext import commands
+from permissioncontroller import PermissionController
+from enum import Enum
+from permissioncontroller import ModuleName
+
+class TicketAction(Enum):
+    ADD = "Add"
+    REMOVE = "Remove"
+
+class RoleAdmin(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+        self.moderator_roles = PermissionController()
+
+    @discord.slash_command(description="Przypisuje lub usuwa danej roli dostęp do danego modułu")
+    @discord.default_permissions(administrator=True)
+    @guild_only()
+    async def modrole(self, ctx, action: discord.Option(TicketAction), role: discord.Role, module: discord.Option(ModuleName)):
+        if action == TicketAction.ADD:
+            self.moderator_roles.add_role_permission(str(role.id), module)
+            await ctx.respond(f"Rola {role.name} otrzymała dostęp do modułu {module.value}", ephemeral=True)
+        else:
+            self.moderator_roles.remove_role_permission(str(role.id), module)
+            await ctx.respond(f"Rola {role.name} utraciła dostęp do modułu {module.value}", ephemeral=True)
+
+def setup(bot):
+    bot.add_cog(RoleAdmin(bot))

--- a/cogs/roleadmin.py
+++ b/cogs/roleadmin.py
@@ -6,7 +6,7 @@ from enum import Enum
 from permissioncontroller import ModuleName
 
 
-class TicketAction(Enum):
+class Action(Enum):
     ADD = "Add"
     REMOVE = "Remove"
 
@@ -24,11 +24,11 @@ class RoleAdmin(commands.Cog):
     async def modrole(
         self,
         ctx,
-        action: discord.Option(TicketAction),
+        action: discord.Option(Action),
         role: discord.Role,
         module: discord.Option(ModuleName),
     ):
-        if action == TicketAction.ADD:
+        if action == Action.ADD:
             self.moderator_roles.add_role_permission(str(role.id), module)
             await ctx.respond(
                 f"Rola {role.name} otrzymała dostęp do modułu {module.value}",

--- a/cogs/ticketadmin.py
+++ b/cogs/ticketadmin.py
@@ -5,64 +5,88 @@ from discord.ext import commands
 from private import ticket_category_id
 from permissioncontroller import PermissionController, ModuleName
 
+
 class TicketModal(discord.ui.Modal):
     def __init__(self, moderator_roles: PermissionController):
         super().__init__(title="Utwórz ticket")
         self.moderator_roles = moderator_roles
-        self.add_item(discord.ui.InputText(label="Proszę, opisz krótko swój problem", placeholder="Wpisz tutaj", style=discord.InputTextStyle.long))
-
+        self.add_item(
+            discord.ui.InputText(
+                label="Proszę, opisz krótko swój problem",
+                placeholder="Wpisz tutaj",
+                style=discord.InputTextStyle.long,
+            )
+        )
 
     async def callback(self, interaction: Interaction):
         category = interaction.guild.get_channel(ticket_category_id)
         member = interaction.user
-        overwrites = {interaction.guild.default_role: PermissionOverwrite(view_channel=False, send_messages=True),
-                      member: PermissionOverwrite(view_channel=True)}
-        moderator_role_ids = self.moderator_roles.get_roles_with_permission(ModuleName.MODERATOR)
+        overwrites = {
+            interaction.guild.default_role: PermissionOverwrite(
+                view_channel=False, send_messages=True
+            ),
+            member: PermissionOverwrite(view_channel=True),
+        }
+        moderator_role_ids = self.moderator_roles.get_roles_with_permission(
+            ModuleName.MODERATOR
+        )
         for role_id in moderator_role_ids:
             role = interaction.guild.get_role(role_id)
             if role:
-                overwrites[role] = PermissionOverwrite(view_channel=True, send_messages=True)
+                overwrites[role] = PermissionOverwrite(
+                    view_channel=True, send_messages=True
+                )
 
         channel = await interaction.guild.create_text_channel(
             name=f"{interaction.user.name}-ticket",
             category=category,
             overwrites=overwrites,
-            reason=f"Ticket stworzony przez użytkownika {member.display_name}"
+            reason=f"Ticket stworzony przez użytkownika {member.display_name}",
         )
 
         description = self.children[0].value
-        embed = discord.Embed(title=f"Ticket", color=0x33cc33)
+        embed = discord.Embed(title=f"Ticket", color=0x33CC33)
         embed.add_field(name="Opis", value=description)
 
         await channel.send(content=f"<@{member.id}>", embed=embed)
-        await interaction.response.send_message(f"Utworzono ticket <#{channel.id}>", ephemeral=True)
+        await interaction.response.send_message(
+            f"Utworzono ticket <#{channel.id}>", ephemeral=True
+        )
 
 
 class CreateTicketView(discord.ui.View):
     def __init__(self, moderator_roles: PermissionController):
         super().__init__(timeout=None)
         self.moderator_roles = moderator_roles
-    
-    @discord.ui.button(label="Utwórz ticket", style=discord.ButtonStyle.green, custom_id="create_ticket_button")
+
+    @discord.ui.button(
+        label="Utwórz ticket",
+        style=discord.ButtonStyle.green,
+        custom_id="create_ticket_button",
+    )
     async def button_callback(self, button, interaction: Interaction):
         # TODO: system sprawdzania czy ten użytkownik nie posiada już ticketa
         await interaction.response.send_modal(TicketModal(self.moderator_roles))
+
 
 class TicketControlModal(discord.ui.Modal):
     def __init__(self, cog):
         super().__init__(title="Zamknij ticket")
         self.cog = cog
 
-        self.add_item(discord.ui.InputText(
-            label="Podaj powód zamknięcia ticketa (opcjonalnie)",
-            placeholder="Wpisz tutaj",
-            required=False
-        ))
+        self.add_item(
+            discord.ui.InputText(
+                label="Podaj powód zamknięcia ticketa (opcjonalnie)",
+                placeholder="Wpisz tutaj",
+                required=False,
+            )
+        )
 
     async def callback(self, interaction: discord.Interaction):
         reason = self.children[0].value
         await self.cog._close_ticket(interaction, reason)
         await interaction.response.defer(ephemeral=True)
+
 
 class CloseTicketView(discord.ui.View):
     def __init__(self, cog):
@@ -70,16 +94,20 @@ class CloseTicketView(discord.ui.View):
         self.cog = cog
         self.moderator_roles = PermissionController()
 
-    @discord.ui.button(label="Zamknij ticket", style=discord.ButtonStyle.red, custom_id="close_ticket_button")
+    @discord.ui.button(
+        label="Zamknij ticket",
+        style=discord.ButtonStyle.red,
+        custom_id="close_ticket_button",
+    )
     async def close_ticket_button(self, button, interaction: discord.Interaction):
         if not interaction.user.guild_permissions.administrator:
             await interaction.response.send_message(
-                "Nie masz uprawnień administratora, aby zamknąć ticket.",
-                ephemeral=True
+                "Nie masz uprawnień administratora, aby zamknąć ticket.", ephemeral=True
             )
             return
 
         await interaction.response.send_modal(TicketControlModal(self.cog))
+
 
 class TicketAdmin(commands.Cog):
     def __init__(self, bot):
@@ -98,7 +126,7 @@ class TicketAdmin(commands.Cog):
             return "❌ To nie jest kanał-ticket."
         return None
 
-    async def _do_close_ticket(self, channel, author, reason = None):
+    async def _do_close_ticket(self, channel, author, reason=None):
         is_ticket_channel = await self._is_ticket_channel(channel)
 
         if is_ticket_channel is not None:
@@ -112,15 +140,23 @@ class TicketAdmin(commands.Cog):
         channel = interaction.channel
         author = interaction.user
 
-        return await self._do_close_ticket(channel=channel, author=author, reason=reason)
+        return await self._do_close_ticket(
+            channel=channel, author=author, reason=reason
+        )
 
     @discord.slash_command(description="Tworzy menu do otwierania ticketów.")
     @discord.default_permissions(administrator=True)
     @guild_only()
     async def create_ticket_menu(self, ctx, channel: discord.TextChannel):
-        embed = discord.Embed(title="Utwórz ticket", color=0xA751ED, description="Utwórz ticket, aby zadać pytanie, zgłosić błąd lub uzyskać pomoc innego typu")
+        embed = discord.Embed(
+            title="Utwórz ticket",
+            color=0xA751ED,
+            description="Utwórz ticket, aby zadać pytanie, zgłosić błąd lub uzyskać pomoc innego typu",
+        )
         await channel.send(embed=embed, view=CreateTicketView(self.moderator_roles))
-        await ctx.respond(f"✅ Utworzone nowe menu na kanale <#{channel.id}>.", ephemeral=True)
+        await ctx.respond(
+            f"✅ Utworzone nowe menu na kanale <#{channel.id}>.", ephemeral=True
+        )
 
     @discord.slash_command(description="Dodaje użytkownika do ticketa.")
     @discord.default_permissions(administrator=True)
@@ -134,9 +170,14 @@ class TicketAdmin(commands.Cog):
                 await ctx.respond("Ten użytkownik już ma dostęp do tego ticketa")
 
             await channel.set_permissions(member, view_channel=True)
-            await ctx.respond(f"✅ Dodano użytkownika <@{member.id}> do ticketa <#{channel.id}>.", ephemeral=True)
+            await ctx.respond(
+                f"✅ Dodano użytkownika <@{member.id}> do ticketa <#{channel.id}>.",
+                ephemeral=True,
+            )
 
-    @discord.slash_command(description="Tworzy menu umożliwiające zamknięcie ticketa przez moderatorów")
+    @discord.slash_command(
+        description="Tworzy menu umożliwiające zamknięcie ticketa przez moderatorów"
+    )
     @guild_only()
     async def close_request(self, ctx):
         channel = ctx.channel
@@ -146,10 +187,13 @@ class TicketAdmin(commands.Cog):
             await ctx.respond(is_ticket_channel, ephemeral=True)
             return
 
-        embed = discord.Embed(title="Kontrola ticketa", color=0xff9900, description="Kliknij w przycisk poniżej, aby zamknąć ticket")
+        embed = discord.Embed(
+            title="Kontrola ticketa",
+            color=0xFF9900,
+            description="Kliknij w przycisk poniżej, aby zamknąć ticket",
+        )
         await ctx.send(embed=embed, view=CloseTicketView(self))
         await ctx.respond("✅ Utworzono panel kontrolny ticketa", ephemeral=True)
-
 
     @discord.slash_command(description="Zamyka ticket")
     @discord.default_permissions(administrator=True)
@@ -157,7 +201,9 @@ class TicketAdmin(commands.Cog):
     async def close(self, ctx, reason: str = None):
         channel = ctx.channel
         author = ctx.author
-        result = await self._do_close_ticket(channel=channel, author=author, reason=reason)
+        result = await self._do_close_ticket(
+            channel=channel, author=author, reason=reason
+        )
 
         if result is not None:
             ctx.respond(result, ephemeral=True)
@@ -173,7 +219,9 @@ class TicketAdmin(commands.Cog):
             await ctx.respond(is_ticket_channel, ephemeral=True)
             return
 
-        await channel.set_permissions(ctx.guild.default_role, view_channel=False, send_messages=False)
+        await channel.set_permissions(
+            ctx.guild.default_role, view_channel=False, send_messages=False
+        )
         # TODO: Loguj zablokowanie ticketa na kanale mod-log
         await ctx.respond("🔒 Pomyślnie zablokowano kanał", ephemeral=False)
 
@@ -188,13 +236,11 @@ class TicketAdmin(commands.Cog):
             await ctx.respond(is_ticket_channel, ephemeral=True)
             return
 
-        await channel.set_permissions(ctx.guild.default_role, view_channel=False, send_messages=True)
+        await channel.set_permissions(
+            ctx.guild.default_role, view_channel=False, send_messages=True
+        )
         # TODO: Loguj zablokowanie ticketa na kanale mod-log
         await ctx.respond("🔓 Pomyślnie odblokowano kanał", ephemeral=False)
-
-
-
-
 
 
 def setup(bot):

--- a/cogs/ticketadmin.py
+++ b/cogs/ticketadmin.py
@@ -1,0 +1,163 @@
+import discord
+from discord import guild_only, PermissionOverwrite, Interaction
+from discord.ext import commands
+
+from private import moderator_role_ids, ticket_category_id
+
+class TicketModal(discord.ui.Modal):
+    def __init__(self):
+        super().__init__(title="Utwórz ticket")
+        self.add_item(discord.ui.InputText(label="Proszę, opisz krótko swój problem", placeholder="Wpisz tutaj"))
+
+
+    async def callback(self, interaction: Interaction):
+        category = interaction.guild.get_channel(ticket_category_id)
+        member = interaction.user
+        overwrites = {interaction.guild.default_role: PermissionOverwrite(view_channel=False, send_messages=True),
+                      member: PermissionOverwrite(view_channel=True)}
+        for role_id in moderator_role_ids:
+            role = interaction.guild.get_role(role_id)
+            if role:
+                overwrites[role] = PermissionOverwrite(view_channel=True, send_messages=True)
+
+        channel = await interaction.guild.create_text_channel(
+            name=f"{interaction.user.name}-ticket",
+            category=category,
+            overwrites=overwrites,
+            reason=f"Ticket stworzony przez użytkownika {member.display_name}"
+        )
+
+        description = self.children[0].value
+        embed = discord.Embed(title=f"Ticket", color=0x33cc33)
+        embed.add_field(name="Opis", value=description)
+
+        await channel.send(content=f"<@{member.id}>", embed=embed)
+        await interaction.response.send_message(f"Utworzono ticket <#{channel.id}>", ephemeral=True)
+
+
+class CreateTicketView(discord.ui.View):
+    def __init__(self):
+        super().__init__(timeout=None)
+    
+    @discord.ui.button(label="Utwórz ticket", style=discord.ButtonStyle.green, custom_id="create_ticket_button")
+    async def button_callback(self, button, interaction: Interaction):
+        # TODO: system sprawdzania czy ten użytkownik nie posiada już ticketa
+        # Zgodnie zwymaganiami, na jednego użytkownika ma przypadać na raz tylko jeden ticket
+        await interaction.response.send_modal(TicketModal())
+
+class TicketControlModal(discord.ui.Modal):
+    def __init__(self, cog):
+        super().__init__(title="Zamknij ticket")
+        self.cog = cog
+
+        self.add_item(discord.ui.InputText(
+            label="Podaj powód zamknięcia ticketa (opcjonalnie)",
+            placeholder="Wpisz tutaj",
+            required=False
+        ))
+
+    async def callback(self, interaction: discord.Interaction):
+        reason = self.children[0].value
+        await self.cog._close_ticket(interaction, reason)
+        await interaction.response.defer(ephemeral=True)
+
+class CloseTicketView(discord.ui.View):
+    def __init__(self, cog):
+        super().__init__(timeout=None)
+        self.cog = cog
+
+    @discord.ui.button(label="Zamknij ticket", style=discord.ButtonStyle.red, custom_id="close_ticket_button")
+    async def close_ticket_button(self, button, interaction: discord.Interaction):
+        if not interaction.user.guild_permissions.administrator:
+            await interaction.response.send_message(
+                "Nie masz uprawnień administratora, aby zamknąć ticket.",
+                ephemeral=True
+            )
+            return
+
+        await interaction.response.send_modal(TicketControlModal(self.cog))
+
+class TicketAdmin(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_ready(self):
+        self.bot.add_view(CreateTicketView())
+        self.bot.add_view(CloseTicketView(self))
+
+    async def _is_ticket_channel(self, channel):
+        if not isinstance(channel, discord.TextChannel):
+            return "❌ To nie jest kanał tekstowy."
+        elif channel.category_id != ticket_category_id:
+            return "❌ To nie jest kanał-ticket."
+        return None
+
+    async def _do_close_ticket(self, channel, author, reason = None):
+        is_ticket_channel_result = await self._is_ticket_channel(channel)
+
+        if is_ticket_channel_result is not None:
+            return is_ticket_channel_result
+
+        await channel.delete(reason=f"Closing ticket by {author}")
+        # TODO: Loguj usunięte tickety na kanale mod-log
+        return None
+
+    async def _close_ticket(self, interaction: discord.Interaction, reason: str = None):
+        channel = interaction.channel
+        author = interaction.user
+
+        return await self._do_close_ticket(channel=channel, author=author, reason=reason)
+
+    @discord.slash_command(description="Tworzy menu do otwierania ticketów.")
+    @discord.default_permissions(administrator=True)
+    @guild_only()
+    async def create_ticket_menu(self, ctx, channel: discord.TextChannel):
+        embed = discord.Embed(title="Utwórz ticket", color=0xA751ED, description="Utwórz ticket, aby zadać pytanie, zgłosić błąd lub uzyskać pomoc innego typu")
+        await channel.send(embed=embed, view=CreateTicketView())
+        await ctx.respond(f"✅ Utworzone nowe menu na kanale <#{channel.id}>.", ephemeral=True)
+
+    @discord.slash_command(description="Dodaje użytkownika do ticketa.")
+    @discord.default_permissions(administrator=True)
+    @guild_only()
+    async def add(self, ctx, member: discord.Member, channel: discord.TextChannel):
+        # TODO: dostosuj w kodzie nazwę kategorii, aby pasowała do rzeczywistej nazwy
+        if channel.category.id != ticket_category_id:
+            await ctx.respond("Wskazany kanał nie znajduje się w kategorii tickety")
+        else:
+            if member in channel.overwrites:
+                await ctx.respond("Ten użytkownik już ma dostęp do tego ticketa")
+
+            await channel.set_permissions(member, view_channel=True)
+            await ctx.respond(f"✅ Dodano użytkownika <@{member.id}> do ticketa <#{channel.id}>.", ephemeral=True)
+
+    @discord.slash_command(description="Tworzy menu umożliwiające zamknięcie ticketa przez moderatorów")
+    @guild_only()
+    async def close_ticket(self, ctx):
+        channel = ctx.channel
+        is_ticket_channel_result = await self._is_ticket_channel(channel)
+
+        if is_ticket_channel_result is not None:
+            ctx.respond(is_ticket_channel_result, ephemeral=True)
+
+        embed = discord.Embed(title="Kontrola ticketa", color=0xff9900, description="Kliknij w przycisk poniżej, aby zamknąć ticket")
+        await ctx.send(embed=embed, view=CloseTicketView(self))
+        await ctx.respond("✅ Utworzono panel kontrolny ticketa", ephemeral=True)
+
+
+    @discord.slash_command(description="Zamyka ticket")
+    @discord.default_permissions(administrator=True)
+    @guild_only()
+    async def close(self, ctx, reason: str = None):
+        channel = ctx.channel
+        author = ctx.author
+        result = await self._do_close_ticket(channel=channel, author=author, reason=reason)
+
+        if result is not None:
+            ctx.respond(result, ephemeral=True)
+
+
+
+
+def setup(bot):
+    bot.add_cog(TicketAdmin(bot))

--- a/cogs/ticketadmin.py
+++ b/cogs/ticketadmin.py
@@ -9,7 +9,7 @@ class TicketModal(discord.ui.Modal):
     def __init__(self, moderator_roles: PermissionController):
         super().__init__(title="Utwórz ticket")
         self.moderator_roles = moderator_roles
-        self.add_item(discord.ui.InputText(label="Proszę, opisz krótko swój problem", placeholder="Wpisz tutaj"))
+        self.add_item(discord.ui.InputText(label="Proszę, opisz krótko swój problem", placeholder="Wpisz tutaj", style=discord.InputTextStyle.long))
 
 
     async def callback(self, interaction: Interaction):
@@ -46,7 +46,6 @@ class CreateTicketView(discord.ui.View):
     @discord.ui.button(label="Utwórz ticket", style=discord.ButtonStyle.green, custom_id="create_ticket_button")
     async def button_callback(self, button, interaction: Interaction):
         # TODO: system sprawdzania czy ten użytkownik nie posiada już ticketa
-        # Zgodnie zwymaganiami, na jednego użytkownika ma przypadać na raz tylko jeden ticket
         await interaction.response.send_modal(TicketModal(self.moderator_roles))
 
 class TicketControlModal(discord.ui.Modal):

--- a/permissioncontroller.py
+++ b/permissioncontroller.py
@@ -2,10 +2,12 @@ import json
 from pathlib import Path
 from enum import Enum
 
+
 class ModuleName(Enum):
     MODERATOR = "moderator"
     ECONOMY = "ekonomia"
     LEVEL = "poziomy"
+
 
 class PermissionController:
     def __init__(self, filepath="module_roles.json"):
@@ -24,6 +26,7 @@ class PermissionController:
         return roles_map
 
     """Zapisuje roles_map do pliku"""
+
     def _save(self, data=None):
         if data is None:
             data = self.roles_map
@@ -34,6 +37,7 @@ class PermissionController:
             json.dump(serializable_data, f, indent=4)
 
     """Zwraca listę role_id, które mają dane uprawnienie (enum)"""
+
     def get_roles_with_permission(self, module: ModuleName) -> list[int]:
         result = []
         for role_id, perms in self.roles_map.items():
@@ -42,6 +46,7 @@ class PermissionController:
         return result
 
     """Dodaje uprawnienie dla roli"""
+
     def add_role_permission(self, role_id: str, module: ModuleName):
         role_id = str(role_id)
         if role_id not in self.roles_map:
@@ -51,6 +56,7 @@ class PermissionController:
         self._save()
 
     """Usuwa uprawnienie z roli"""
+
     def remove_role_permission(self, role_id: str, module: ModuleName):
         role_id = str(role_id)
         if role_id in self.roles_map and module in self.roles_map[role_id]:
@@ -60,10 +66,12 @@ class PermissionController:
             self._save()
 
     """Sprawdza, czy dana rola ma uprawnienie"""
+
     def has_permission(self, role_id: str, module: ModuleName) -> bool:
         role_id = str(role_id)
         return module in self.roles_map.get(role_id, [])
 
     """Zwraca listę wszystkich role_id"""
+
     def all_roles(self) -> list[int]:
         return [int(role_id) for role_id in self.roles_map.keys()]

--- a/permissioncontroller.py
+++ b/permissioncontroller.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+from enum import Enum
+
+class ModuleName(Enum):
+    MODERATOR = "moderator"
+    ECONOMY = "ekonomia"
+    LEVEL = "poziomy"
+
+class PermissionController:
+    def __init__(self, filepath="module_roles.json"):
+        self.filepath = Path(filepath)
+        self.roles_map = self._load_or_create()
+
+    def _load_or_create(self):
+        if not self.filepath.exists():
+            self._save({})
+            return {}
+        with open(self.filepath, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        roles_map = {}
+        for role_id, perms in data.items():
+            roles_map[str(role_id)] = [ModuleName(p) for p in perms]
+        return roles_map
+
+    """Zapisuje roles_map do pliku"""
+    def _save(self, data=None):
+        if data is None:
+            data = self.roles_map
+        serializable_data = {
+            role_id: [perm.value for perm in perms] for role_id, perms in data.items()
+        }
+        with open(self.filepath, "w", encoding="utf-8") as f:
+            json.dump(serializable_data, f, indent=4)
+
+    """Zwraca listę role_id, które mają dane uprawnienie (enum)"""
+    def get_roles_with_permission(self, module: ModuleName) -> list[int]:
+        result = []
+        for role_id, perms in self.roles_map.items():
+            if module in perms:
+                result.append(int(role_id))
+        return result
+
+    """Dodaje uprawnienie dla roli"""
+    def add_role_permission(self, role_id: str, module: ModuleName):
+        role_id = str(role_id)
+        if role_id not in self.roles_map:
+            self.roles_map[role_id] = []
+        if module not in self.roles_map[role_id]:
+            self.roles_map[role_id].append(module)
+        self._save()
+
+    """Usuwa uprawnienie z roli"""
+    def remove_role_permission(self, role_id: str, module: ModuleName):
+        role_id = str(role_id)
+        if role_id in self.roles_map and module in self.roles_map[role_id]:
+            self.roles_map[role_id].remove(module)
+            if not self.roles_map[role_id]:
+                del self.roles_map[role_id]
+            self._save()
+
+    """Sprawdza, czy dana rola ma uprawnienie"""
+    def has_permission(self, role_id: str, module: ModuleName) -> bool:
+        role_id = str(role_id)
+        return module in self.roles_map.get(role_id, [])
+
+    """Zwraca listę wszystkich role_id"""
+    def all_roles(self) -> list[int]:
+        return [int(role_id) for role_id in self.roles_map.keys()]


### PR DESCRIPTION
TODO:
~~* Dodać komendę `/block`~~ GOTOWE
~~* Dodać komendę `/modrole add/remove`~~ GOTOWE
* Dodać logowanie otwierania/zamykania/blokowania ticketów
* Uzgodnić logikę ustalania czy dany użytkownik ma już jeden otwarty ticket

Co do tego ostatniego, personalnie uważam, że najlepiej trzymać albo szczątkowe informacje o ticketach w bazie danych albo po prostu w profilu użytkowników w bazie dodać pole has_ticket_opened (bool), na bazie którego można by aktualizować nazwy ticketów w przypadku zmiany nazwy użytkownika oraz jak wcześniej wspomniałem, ustalić czy można dla danego użytkownika utworzyć ticket. 
@BRTK-DS czy są jakieś alternatywy, które nie wymagałyby zapisu tej informacji w bazie i jednocześnie umożliwiały szybkie checki nicków i tego czy można dla danego użytkownika utworzyć ticket? Mimo wszystko lepiej unikać niepotrzebnych requestów do api discorda