### PR TITLE
Dodanie funkcji usuwania wiadomości na podstawie decyzji społeczności. 

### DIFF
--- a/cogs/slopometer.py
+++ b/cogs/slopometer.py
@@ -1,0 +1,21 @@
+import discord
+from discord.ext import commands
+
+class slopometer(commands.Cog):
+    def __init__(self, bot):
+        self.bot = bot
+
+    @commands.Cog.listener()
+    async def on_reaction_add(self, reaction, user):
+        if user.bot:
+            return
+        # Podany poniżej kanał to #memy-tidzimi z serwera "Serwer TIDZIMIEGO"
+        if reaction.message.channel.id != 1376823727035121674:
+            return
+        # Emoji, które powinno być na serwerze discord.
+        if reaction.emoji.name == "slop":
+            if reaction.count >= 15:
+                await reaction.message.delete()
+
+def setup(bot):
+    bot.add_cog(slopometer(bot))


### PR DESCRIPTION
Sugeruję dodać funkcję, która będzie usuwała wiadomości z kanału `#tidzimi-memy` na podstawie decyzji społeczności.

Na kanale `#propozycje` serwera `Serwer TIDZIMIEGO` społeczność zgodziła się na tę zmianę, 27 osób zagłosowało na tak, a 1 zagłosowała na nie. 

W skrócie jest to związane z tym, że na memach jest mnóstwo low-effort AI slopu, który nie jest śmieszny.
Przez te wiadomości, dobre i śmieszne memy zostają w tyle, i mogą liczyć na mniejsze docenienie.

Bot specjalnie nie wysyła automatycznie emotki "slop", żeby nie zachęcać do trolowania.

Liczba reakcji jest ustawiona na 15, jest to moim zdaniem optymalna liczba reakcji, bazując na średniej od 10 do 20.

Proponowana emotka ":slop:" znajduje się w poniższym załączniku, a informacje o tej funkcji można zawrzeć w temacie kanału.

<img width="100" height="100" alt="slop" src="https://github.com/user-attachments/assets/8698fcf6-04b0-4b02-842d-de710f5e59f2" />


